### PR TITLE
Handle `No valid destinations found` error

### DIFF
--- a/client.py
+++ b/client.py
@@ -68,14 +68,18 @@ message.attach(part)
 subject = 'Connekt SMTP Client'
 message['Subject'] = Header(subject, 'utf-8')
 
-try:
-    smtpObj = smtplib.SMTP() 
-    smtpObj.connect("localhost", 1025) 
-    smtpObj.login("username","password")
+with smtplib.SMTP("localhost:1025") as smtp:
+  try:
+      smtp.set_debuglevel(2)
+      # smtp.connect("localhost", 1025)
+      smtp.starttls() 
 
-    smtpObj.sendmail(sender, receivers, message.as_string())
-    print ("Email Sent")
+      smtp.login("username","password")
 
-except smtplib.SMTPException as e:
-    print(e)
-    print ("Error: Send Exception")
+      smtp.sendmail(sender, receivers, message.as_string())
+      print ("Email Sent")
+
+  except smtplib.SMTPException as e:
+      print(e)
+      print ("Error: Send Exception")
+

--- a/connekt/model.go
+++ b/connekt/model.go
@@ -41,7 +41,7 @@ type ConnektResponse struct {
 		Type    string                 `json:"type"`
 		Message string                 `json:"message"`
 		Success map[string]interface{} `json:"success"`
-		Failure interface{}          `json:"failure"`
+		Failure interface{}            `json:"failure"`
 	} `json:"response"`
 }
 

--- a/smtp/backend.go
+++ b/smtp/backend.go
@@ -16,7 +16,7 @@ func (bkd *Backend) Login(state *smtp.ConnectionState, username, password string
 	if username == "smtp" {
 		username = defaultConnektApp
 	}
-	log.Println("Connection from", state.RemoteAddr.String(), state.Hostname, "AppName: "+ username)
+	log.Println("Connection from", state.RemoteAddr.String(), state.Hostname, "AppName: "+username)
 	return &Session{APIKey: password, AppName: username}, nil
 }
 


### PR DESCRIPTION
- Return 500 for bad destinations so that intermediary relay's don't reattempt.